### PR TITLE
Fix to catch block in install.js

### DIFF
--- a/install.js
+++ b/install.js
@@ -172,7 +172,7 @@ async function download() {
             try {
               const versions = JSON.parse(data);
               return resolve(versions.FIREFOX_NIGHTLY);
-            } catch {
+            } catch (error) {
               return reject(new Error('Firefox version not found'));
             }
           });


### PR DESCRIPTION
The install process was failing on npm due to a syntax error in the catch statement on line 175.